### PR TITLE
Fix data privacy UI toggle bug

### DIFF
--- a/composeApp/src/commonMain/kotlin/me/shadykhalifa/whispertop/presentation/ui/components/StatisticsPreferencesSection.kt
+++ b/composeApp/src/commonMain/kotlin/me/shadykhalifa/whispertop/presentation/ui/components/StatisticsPreferencesSection.kt
@@ -26,6 +26,7 @@ import me.shadykhalifa.whispertop.domain.models.displayName
 fun StatisticsPreferencesSection(
     settings: AppSettings,
     validationErrors: Map<String, String> = emptyMap(),
+    optimisticDataPrivacyMode: DataPrivacyMode?,
     onStatisticsEnabledChange: (Boolean) -> Unit,
     onHistoryRetentionDaysChange: (Int) -> Unit,
     onExportFormatChange: (ExportFormat) -> Unit,
@@ -93,6 +94,7 @@ fun StatisticsPreferencesSection(
             // Privacy Section
             PrivacySection(
                 dataPrivacyMode = settings.dataPrivacyMode,
+                optimisticDataPrivacyMode = optimisticDataPrivacyMode,
                 onDataPrivacyModeChange = onDataPrivacyModeChange
             )
         }
@@ -408,6 +410,7 @@ private fun NotificationsSection(
 @Composable
 private fun PrivacySection(
     dataPrivacyMode: DataPrivacyMode,
+    optimisticDataPrivacyMode: DataPrivacyMode?,
     onDataPrivacyModeChange: (DataPrivacyMode) -> Unit
 ) {
     Column(
@@ -424,13 +427,14 @@ private fun PrivacySection(
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             DataPrivacyMode.entries.forEach { mode ->
+                val isSelected = mode == (optimisticDataPrivacyMode ?: dataPrivacyMode)
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.Top,
                     horizontalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     RadioButton(
-                        selected = mode == dataPrivacyMode,
+                        selected = isSelected,
                         onClick = { onDataPrivacyModeChange(mode) }
                     )
                     Column(
@@ -440,7 +444,7 @@ private fun PrivacySection(
                         Text(
                             text = mode.displayName,
                             style = MaterialTheme.typography.bodyMedium,
-                            fontWeight = FontWeight.Medium
+                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium
                         )
                         Text(
                             text = mode.description,

--- a/composeApp/src/commonMain/kotlin/me/shadykhalifa/whispertop/presentation/ui/screens/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/me/shadykhalifa/whispertop/presentation/ui/screens/SettingsScreen.kt
@@ -165,6 +165,7 @@ fun SettingsScreen(
                 StatisticsPreferencesSection(
                     settings = uiState.settings,
                     validationErrors = uiState.statisticsPreferencesValidationErrors,
+                    optimisticDataPrivacyMode = uiState.optimisticDataPrivacyMode,
                     onStatisticsEnabledChange = viewModel::updateStatisticsEnabled,
                     onHistoryRetentionDaysChange = viewModel::updateHistoryRetentionDays,
                     onExportFormatChange = viewModel::updateExportFormat,


### PR DESCRIPTION
## Changes

- **Added optimistic data privacy mode toggle** to improve UI responsiveness
- **Updated StatisticsPreferencesSection** to accept and pass `optimisticDataPrivacyMode` parameter
- **Modified PrivacySection** to use optimistic mode for immediate UI feedback while maintaining actual data privacy mode
- **Enhanced radio button selection logic** to show bold text for selected mode
- **Improved visual feedback** with conditional font weight based on selection state

## Tests

- **Manual testing required**: 
  - Verify that the data privacy mode toggle provides immediate visual feedback
  - Test that the selected mode shows bold text while other modes remain normal weight
  - Ensure the actual data privacy mode is correctly updated after user selection
  - Test edge cases where optimistic mode might be null

## Documentation

- No new documentation needed as this is a UI enhancement to existing functionality

## Follow-up Recommendations

- Consider adding unit tests for the UI component behavior
- Evaluate if optimistic state should persist across navigation or be reset
- Monitor for any performance impacts from the additional parameter passing

---

[Open in Shadow](https://shadowrealm.ai/tasks/vasPuWgsFKIw)